### PR TITLE
README 推广新项目并切换站点域名

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## 项目概述
 
-竹知了 —— 传统玩具的 Web 模拟版（甩起来"哇哇"叫的竹筒玩具）。核心承诺：**零依赖、单文件、无构建、纯前端**，用浏览器直开 `index.html` 即可玩（含 `file://`）。线上地址 <https://zhuzhiliao.icu>，纯静态走 Cloudflare Pages，**没有任何后端**（页面加载完不发任何请求）。
+竹知了 —— 传统玩具的 Web 模拟版（甩起来"哇哇"叫的竹筒玩具）。核心承诺：**零依赖、单文件、无构建、纯前端**，用浏览器直开 `index.html` 即可玩（含 `file://`）。线上地址 <https://imsai.top>，纯静态走 Cloudflare Pages，**没有任何后端**（页面加载完不发任何请求）。
 
 许可不是开源：源码公开供学习，禁止再分发/公开部署/商用，见 `LICENSE`。改动 README 或页面文案时不要写"开源"，用"源码公开"。
 

--- a/README.md
+++ b/README.md
@@ -2,12 +2,17 @@
 
 一转就"哇哇"叫的传统玩具，Web 模拟版。零依赖单文件，手机优先。
 
-**在线试玩：<https://zhuzhiliao.icu>**
+**在线试玩：<https://imsai.top>**
+
+> [!TIP]
+> **新开源项目：[Awesome DeepSeek Harness Plugins](https://github.com/imsai-sh/awesome-deepseek-harness-plugins)**
+>
+> 面向 DeepSeek harness 插件生态的 Awesome 清单，欢迎 Star 和共建。
 
 > [!CAUTION]
-> **本项目不是开源项目，未授权任何人再分发或公开部署。**
+> **本项目未授权任何人再分发或公开部署。**
 >
-> 官方站点只有 <https://zhuzhiliao.icu>，**其他任何域名上的部署都未经授权**。
+> 官方站点只有 <https://imsai.top>，**其他任何域名上的部署都未经授权**。
 >
 > 已发现有人擅自修改本项目代码后公开部署，包括将页面中作者原创的手绘小蝉形象替换为
 > 真实人物形象。此类衍生版本与本项目及作者没有任何关系，作者未参与、未授权、也不
@@ -17,7 +22,7 @@
 > 源码公开仅供学习交流，权利范围见 [LICENSE](LICENSE)。
 >
 > *This project is NOT open source. Redistribution and public deployment are not
-> permitted. The only official site is <https://zhuzhiliao.icu> — any deployment
+> permitted. The only official site is <https://imsai.top> — any deployment
 > on another domain is unauthorized and unaffiliated with this project or its author,
 > who bears no responsibility for its content. See [LICENSE](LICENSE).*
 
@@ -99,7 +104,7 @@ python3 -m http.server 8123
 做法有点意思：
 
 - 点个 [⭐ Star](https://github.com/imsai-sh/zhuzhiliao/stargazers) —— Star 多了才排得上 GitHub 的搜索和推荐
-- 把 <https://zhuzhiliao.icu> 甩给一个也玩过竹知了的人，看他愣两秒
+- 把 <https://imsai.top> 甩给一个也玩过竹知了的人，看他愣两秒
 - 有 Bug、有想法、有更像真玩具的调参，欢迎提 Issue / PR
 
 ## 许可与声明
@@ -112,7 +117,7 @@ python3 -m http.server 8123
 - **内容限制**：不得用本项目或其修改版制作、传播侵犯他人合法权益的内容，包括未经许可
   使用真实人物的姓名、肖像、声音或其他人格标识；违反者许可自动终止
 
-官方站点只有 <https://zhuzhiliao.icu>，其他域名上的部署均未经授权，与本项目和作者
+官方站点只有 <https://imsai.top>，其他域名上的部署均未经授权，与本项目和作者
 无关——详见[页首声明](#竹知了)。需要超出上述范围的授权，请先联系作者取得书面许可。
 
 ### 关于 Issue 与讨论区

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
 <meta name="theme-color" content="#0a1028">
 <meta name="description" content="竹知了（又叫竹蝉、拉线蝉）网页版免费在线玩：按住画圈甩起来，一转就“哇哇”叫，转得越快叫得越响。真实录音采样与物理模拟还原松香线摩擦发声，无需下载，手机电脑直开即玩，找回儿时的夏天。">
 <meta name="keywords" content="竹知了,竹蝉,拉线蝉,知了哇呜,竹知了在线玩,竹知了网页版,一转就哇哇叫,传统玩具,民间玩具,怀旧玩具">
-<link rel="canonical" href="https://zhuzhiliao.icu/">
+<link rel="canonical" href="https://imsai.top/">
 <link rel="icon" type="image/png" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAOj0lEQVR4AcRZeZBV1Zn/fef1CjSLzWo3S7MrAopglLgCwUo0ohiTmKQymUoyOmYyMzVTFSOpmaQ0Jk5pqjJxYsbRGp2K40yZmKgUSINAIypLlD0kEBfKAGGHZu/u133n9/vOu+/d13SoYeaPXM/vfOv5vu8s99xHG3Cep2H87Q80Trg9+ZNi/O0/Ok+J6HECjePnbWicMC8xS7537uCEqgsB3cvahYylr+Hr6QKWhSkI50ygYfy8hMOuUCdAXQYZ1k2gcxbn2umQUWbYCx7PhWWwQuUFUjaBhvG30YEtU1FCPgtQziJrE5+1iZcuC+myyNrEZ23ipcsi1lionqQ4gYZxn6Qfi+cSJQX4EpHvTv/U9otVK4tX8wlIwdILa5vlOCd6lTRxTdQLspbborZvXQ0G1fdBw7ABjoH1dairq/0/x6+pqcatt8wqG88F38DSCi9x2SoDs26YieqqKlVDn24ldhO1O1WVOaxZ9A94d92jxGPY8NpDWLP422h5aYFjzeJ/pO5B2qL9nWUPok+vmhi/LDeDsxUqjXYKZ86excJFy2MtBTtPwRVUIFw87hZeUwUtnTVq57vvI5/P00599wQFH/nd1fsY3l3/GLa/8QgGDexL//K29+/+HgK6Pf369sKmld/1sYqhWH8U58nfMPbWBwLr+TpggAP+7N79B3R2djrvndEuuAB8re9hLBryAb6/8umC5lyy/8EHkT9wwCH+XI+oUQzFUsyo6aFXbqGbiUf4eyHquNKcSeR76NNVoGl8ZRs+UXuc3Plbv3nzig5ZvqjsxijmoFy+m7YgZvIXNEXCCaTFR8qzxWPNuXGQ+O5b+zd9DxUHv/2pz+GFn71clLNMzdSpaPzJEw7xWVvKa6xipPJ3+u8vy91T/u71BNbJQVSz/p4GSJf1GVXR7vm+9fsD2HTb53H/gofQNG564Z1xU7ELdXUQiooCo/frhjl3YvHSN3HX5p1QLJlibBbipyHS7vmztYjvtgMKQ3CsjOQKjYpi0Kh659RZ3PzxW6LA/rvX34wdn5zv2PPwIzj4H8+hdflKh3jpUrt87/r03fjcF77IkYBiOZN2TPfH8xeM7pCAO1A6LnG2lAvFStb2ZOmuPK9XJuJrjetnTicX2xRdi5HFybXrceTnv8C+Hz7uEC9dwQz5/uDRR3DPV77kKsUSo9jKpQp4Jpg6FisdBTZaWDh7VsiePHdAQ7PgIJoVQJAka0q/fWSgRLw4frhTdb1DwKTaarH/K8hXY1LnNNYPj11ElTKVII5Kr0hUNWXBa5QunAmnR714upH4CKfsMvYD+RzOTh6FXsGwZOIIx4vjGznowprGpOMV6/Coeuxor0QpL+MxdamuhN+aAefY4w5oDwWOueii/uy7NdkEqnUdn7pxCk594250zZmBzslj0DqyHtUzr0Cv62ag9rrpqL32StR8dBpqqKueeTmqr5mCqqsno2LGpcC0CeiaMgZHG/vj1NihODZ9DHZ+9mrsmdoIxWaKc5tyC+da9FOC00xXmNMfNnQQ3agjn07XyAvBEojSAWTQ9dGp+N24/hjxzW9gW2MV+n/1MxhA9PvKXej75TtR9+d3oO5L89D7z25D7y/eiqq7b4bNvxG/barDiAfux65JQ3F88khAwQD2jK8cAnOm+dNdOHjwMIq6gj1QU9a2bd9BU0IdoUCcORtCujwSaFWTqrKqFvVDGjHnzr/E6ld7/iYg8+zcvBkf//zfon5wA3rX1WcsZBk7LlCaO+GkAOVB4eGr6/Wl9JxbiDWDcSISwLQ74EOq4CUZ6OhoR9MlV9IIVFRWYe6n78Pqxa+4nHYMkbLYsnYd5n72rxBCznXDx1yKrs5O8tFLsZU7UCOqWnzFmbtI5ZoBfUuSCpRjGWUUQxdDdnFSiYOCt6MH9mP42EnY8Poil/d88BvM/cx9eHPJQu564jrvyK5vWUnb17Dng9+6auMbr2LoyHE4c/KEy+qMa6v8QsqXUa+FwTghv1rp7zvAbBxPAxUa7DKdxGtVRIGMnd5qZ0+fRlVNL0y66iaJOHX8mNNZ87+Kt5o5CY8HrF3RjNl33kNbgo62s6TApdNvQK8+/ZDv6HBZR0J5vGDlJpxnDKeUvS7K8hM0ieBbxY6NqwuedUBnrgygnpDOB5BXM3VEZVU12s6exvip12Dn5jV+nGbNv4dHZjXWr1iK2fPvdd1vNqzGqImXo52+1dW1HFneFL9H0E165VZO8Q7qpYMrKUhJ4jLPllPpiqBRviRlTWf61+tXuK7vgEFOq6pruMKDMLhhHMRLmdp2bHoLUFCUohn5Yk6AUgaGuLAANEw7ErgT4oOFxJWaSVRIjnAdOJiINrgvCk9VTQ1On2h1SUdJzNARY7FxdXwnjhzci8uumi01dYvR0HSJ89W1vZ125tuRq6hwXp1yCH5d67wbYuEGsEE2Fe+UCvGs0WBAASwcQGklKBugAXQEWQf0UOg/aDAO7t0liYXOwrFD+yL/kTlY/uLT0K1UyZ3QuzJpxo1uO3X8qB81Cb9/79eo7dOHLIMV+uLKusz8pF4PXdgQWExgFVZA0CwcmjGdvRl7wYmCEHyJOBb8Yxe1sVXX1GI3i4gS/PyLP3boDxjSOFqsY+u613iM4pnf/vYq16k7uGcXd4A/HyQQik8CT81OsvJ5fX5kEpoJ1qqXWDafALVsNMhJYLG+Es4jBgQf6hmXDBvd2XDi2CEKsU24fKbfMpvXLMPkqz/GOz6P3e9vx1Wz56Mzr/semDpzbnRmf2DP++zVFAn+zSkWq9zgw5zsYyPv9gLVJII6KXVFqTjnOVgjJMsuSC+Il83BQPVDhqC97YyL/eqHoPmFJ/CxT93rsnf0EdVR2vDGYr92JQvV/AkeS5ckJMXFSnOXaMkWa5CcgBPgQG6JtisaKKt5YjrR5npRIk5CDhFDRzZhbfPPosC+tlcd+9jeXvUK9FJL6sx3YMKUa8Q6Wl55Fv3qB5JPCGVIoCPBbaCcOGKuyMujZAPixAA/QvpYybkMhWKjjgMYx4DiQGSek8cPo6urE+uX/wI33fFlfpzasGXNUsy46Q7e/9U8Pu34VcvLqOMV28kPlz5eJ44cKOxzKVAaPz2+KjrmT5iX4KKWyYzACQBafR/MTryUZKk3BBAUpAsAZEe3Z9r1s3nrPIVWFpXLVfA0JhgxbjJ9OZC+h/btxlWz5pMDLOTQ8vIzGD5hAqI17Q1mtANFGmAIVOaoDwB5UFOiBiDkgiEnp5SmfEEOWVrgUXzMuRACOtrP4LpPfMHl321Zy+MxxPk8f/DV8N5PuENSnDh6kN+OIzDTWgIxAvwp1RGQUy4iCBYQAsExOZctazcaCYsOgU6BYZ0yutMgewrEhza6Rp59ZWUtj0sV1i1/kb9zboQxnorfunaZTyZXUelH653XF/ILzX9ZcQxDsFeLXGCeHEUSrrYRIEipkM3BpBRBggDaJQQYRHMGUoNRCEZdIAzUgbsEp4F6FB4eSefa+bfLyz4yC9t+tQLTrr3Fdep0/0/mdSpeaHn5WdQPHY5L+EMuz3dBuiwCBS8yGHNF+IQARGpRn9pFfZCBBsDMnLqzAUUbpBeoM8QnIRFPunXdarQe3u9f4xx/GuTb27D97Rbe+Tf7rnR2duDNV593+2R+pc+cPI6977/HV5AxvCXexwWE5y3yBgTWZWak4gmvJ6U0sFFFhSHjlPJxoAG0mQPpU9iC2t4D+PNgphdrIeBE6yGMvnQ6Al9Yua5pfgGDho3E4IYmhFwOYy6bjj794o+++DNaXoCZIYAwgCx5UUOgrJspUhRkiz7lSiAA0WBAYBTJDgNEtTLIPGdOncDoSVd6YVIf50uqj1ZldbV/lZfyw9Y08XIMa5oI2eRjFjCM/5hJ/20gnSai+MGA4HktUgPYIk8uUCj5ASHIuTvc0TiIDrRZEF8CMs/Bvbv9ypSq9fABWAjoXdcfgXTFL5+Cbp+LR02grp/bdNXKd+IV1+Jk6zGxRYQ0DzVkUQQZM2PMWA9F2ihLl2OXIpAXcsGQ6nIG8gVQH+iDzHP86FGXvHgD6vrV451VC7Hqpadx9Zy5vP9nY+VL/4Zt65a7zbg46SQ62jp8rDrpc4ydMxSvyJzLVsyv3I4QfAKyU04WhGCuCBxQ5ENBR5qzwKCBPgxuKD30z1VUQf+0q6ytw77du/DMDxbg6X//bzz50yW49y++ifvu/Raeem4ZnvjJM3j+xw/hw3e3o6Z3f365E74z1ZxOKWAgW8zP2CmvQrWoIaNz3vB42LR9+fejYJBTj848dPKRTUEffmwjmBkffriXN0kFXn3+x3juX76Dhx9+FMve2oHWk23o/ki3qGUL/vlHT+LJf7ofS1/4V+QqarFvv3bQ8NOfH/X8nicYV924YFbUBRav/EUEw8btr/01S4McN1KGmRGAAdQRTo08QU8zUlqTLuCRx5bimWdfwitLXsd//nIVWta/h448DQBwHpxpy2P9tr0+pnnFW1i4ZB2e/a8P+Of5JOYxMAPIR5gZtGhBVEDUsxxy5NWv39o8zR0oyBAMCAwTNMBAnuBVHQwQjH6d+fjnkNaT8f8XUHXB7cCR03FMcszjBkrBcxrMDAEC2IM8qRUAcBGWUoLrKQJrtjRbMCBwoJmBLYLWlJctGOgDXpH8rZPkaP1/Nsbo6BgM43+BiYLB4weGpVjOUxeoXLs1Fk8R8hN1vLm52czgSqNGRg0ogjozi3Y6tLc1Id82AnANyYU0FX62iQvBj5sBweAwxnCwk86KEzO3q0ZkHtWYEYHVm+JO5AwcYAQpCEOJZ+RcOhFUoattNLraxyJpH42kYzjQ2R9Iajiq0MR3DnBb0j6G/mPpr8JzpZgGlgrKVgI1TAWmEja+ztrQ7QndZBdbNjbbSoKDHzczDi7BXyh6UQ3nyRSp5RBQA+saBMsPR8iPi+gcDksGui1YQOAYMyvREPlSHNAGGPVmWLBywxJr2bBkGnp4/gcAAP//PUcxvQAAAAZJREFUAwBddM5Te+aGEwAAAABJRU5ErkJggg==">
 <link rel="apple-touch-icon" href="apple-touch-icon.png">
 <link rel="manifest" href="manifest.webmanifest">
@@ -15,26 +15,26 @@
 <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
 <meta name="apple-mobile-web-app-title" content="竹知了">
 <meta property="og:type" content="website">
-<meta property="og:url" content="https://zhuzhiliao.icu/">
+<meta property="og:url" content="https://imsai.top/">
 <meta property="og:site_name" content="竹知了">
 <meta property="og:locale" content="zh_CN">
 <meta property="og:title" content="竹知了 · 一转就哇哇叫">
 <meta property="og:description" content="还记得小时候甩起来哇哇叫的竹蝉吗？按住画圈甩起来，转得越快叫得越响。免费网页版，无需下载，直开即玩。">
-<meta property="og:image" content="https://zhuzhiliao.icu/og-image.jpg">
+<meta property="og:image" content="https://imsai.top/og-image.jpg">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="竹知了 · 一转就哇哇叫">
 <meta name="twitter:description" content="传统竹蝉玩具的网页模拟版：按住画圈甩起来，转得越快叫得越响。免费、无需下载，直开即玩。">
-<meta name="twitter:image" content="https://zhuzhiliao.icu/og-image.jpg">
+<meta name="twitter:image" content="https://imsai.top/og-image.jpg">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
   "@graph": [
     {
       "@type": "WebSite",
-      "@id": "https://zhuzhiliao.icu/#website",
-      "url": "https://zhuzhiliao.icu/",
+      "@id": "https://imsai.top/#website",
+      "url": "https://imsai.top/",
       "name": "竹知了",
       "alternateName": "竹知了 · 一转就哇哇叫",
       "inLanguage": "zh-CN",
@@ -42,10 +42,10 @@
     },
     {
       "@type": ["WebApplication", "VideoGame"],
-      "@id": "https://zhuzhiliao.icu/#app",
+      "@id": "https://imsai.top/#app",
       "name": "竹知了",
       "alternateName": ["竹蝉", "拉线蝉", "知了哇呜"],
-      "url": "https://zhuzhiliao.icu/",
+      "url": "https://imsai.top/",
       "description": "传统民间玩具“竹知了”（竹蝉/拉线蝉）的网页模拟版——甩起来会哇哇叫的竹筒玩具。真实物理模拟加真实录音采样，转得越快叫得越响。免费、无广告、无需下载安装，手机和电脑浏览器打开即玩，源码公开。",
       "inLanguage": "zh-CN",
       "applicationCategory": "GameApplication",
@@ -56,11 +56,11 @@
       "playMode": "https://schema.org/SinglePlayer",
       "isAccessibleForFree": true,
       "offers": { "@type": "Offer", "price": "0", "priceCurrency": "CNY", "availability": "https://schema.org/InStock" },
-      "image": "https://zhuzhiliao.icu/og-image.jpg",
-      "screenshot": { "@type": "ImageObject", "url": "https://zhuzhiliao.icu/og-image.jpg", "inLanguage": "zh-CN" },
+      "image": "https://imsai.top/og-image.jpg",
+      "screenshot": { "@type": "ImageObject", "url": "https://imsai.top/og-image.jpg", "inLanguage": "zh-CN" },
       "author": { "@type": "Person", "name": "imsai" },
       "keywords": "竹知了,竹蝉,拉线蝉,传统玩具,民间玩具,怀旧玩具,网页玩具,在线小游戏",
-      "isPartOf": { "@id": "https://zhuzhiliao.icu/#website" }
+      "isPartOf": { "@id": "https://imsai.top/#website" }
     }
   ]
 }

--- a/robots.txt
+++ b/robots.txt
@@ -1,4 +1,4 @@
 User-agent: *
 Allow: /
 
-Sitemap: https://zhuzhiliao.icu/sitemap.xml
+Sitemap: https://imsai.top/sitemap.xml

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
-    <loc>https://zhuzhiliao.icu/</loc>
+    <loc>https://imsai.top/</loc>
     <lastmod>2026-08-02</lastmod>
     <changefreq>monthly</changefreq>
     <priority>1.0</priority>


### PR DESCRIPTION
## 变更

- 在 README 开头增加 Awesome DeepSeek Harness Plugins 的醒目推广卡片
- 将官方站点域名从 `zhuzhiliao.icu` 切换为 `imsai.top`
- 同步更新 canonical、Open Graph、Twitter Card、JSON-LD、robots.txt、sitemap.xml 和项目说明
- 保留当前 README 中更简洁的未授权部署警告文案

## 影响

文档、社交分享卡片、结构化数据和搜索引擎入口将统一指向新域名，避免上线后继续暴露旧地址。

## 验证

- `git diff --cached --check`
- `xmllint --noout sitemap.xml`
- 全仓搜索确认无 `zhuzhiliao.icu` 残留