### PR TITLE
README 补充 Star History 趋势图

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,14 @@ python3 -m http.server 8123
 - 把 <https://imsai.top> 甩给一个也玩过竹知了的人，看他愣两秒
 - 有 Bug、有想法、有更像真玩具的调参，欢迎提 Issue / PR
 
+<a href="https://www.star-history.com/#imsai-sh/zhuzhiliao&Date">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=imsai-sh/zhuzhiliao&type=Date&theme=dark" />
+    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=imsai-sh/zhuzhiliao&type=Date" />
+    <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=imsai-sh/zhuzhiliao&type=Date" />
+  </picture>
+</a>
+
 ## 许可与声明
 
 **本项目不是 OSI 意义上的开源项目。** 源码公开是为了技术分享，完整条款见 [LICENSE](LICENSE)：


### PR DESCRIPTION
## 变更

- 将 `claude/readme-star-trend-chart-5f969c` 中的 Star History 提交接入最新 `main`
- 在 README 的 Star 号召段落后展示仓库星标历史趋势
- 根据访问者的明暗主题自动选择对应 SVG

## 原因

该提交此前仅存在于独立 Claude 分支，没有进入 PR #97，因此合并后主分支看不到趋势图。

## 验证

- `git diff --check origin/main...HEAD`
- 确认 PR 相对 `main` 仅新增 README 8 行
- Star History 明暗主题 SVG 地址均返回 HTTP 200